### PR TITLE
Support for extracting archive, add licence headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,8 @@ BSD License
 
 
 Copyright (c) 2013, Damian Moore
+Copyright (c) 2013, Chris Horler
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/samsung_bios_check.py
+++ b/samsung_bios_check.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# This file is sourced from the project https://github.com/damianmoore/samsung-bios-check
+# Copyright (C) 2013 Damian Moore
+# For licencing please refer to the the project LICENSE file
+
 from re import findall
 from subprocess import Popen, PIPE
 from time import sleep

--- a/samsung_extract_archive.py
+++ b/samsung_extract_archive.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python2.7
 
+# This file is sourced from the project https://github.com/damianmoore/samsung-bios-check
+# Copyright (C) 2013 Chris Horler
+# For licencing please refer to the the project LICENSE file
+
 import sys
 import os
 import argparse


### PR DESCRIPTION
Hi Damian,

I had a look at the ITEM..exe download yesterday in a hex editor and came up with the attached script, I've tested it on two files.

You'll need the pefile library to execute it as it turns out there's a absolute reference in the DOS Header of the exe.  See script source for more details.

I also added my name to the licence and updated the python sourced to add a header in case anyone wished to use them elsewhere so that we can be credited.

Chris

PS:  There may be a bug in your download script - I'll provide details when I have them... currently I'm getting the wrong file.
